### PR TITLE
Migrate to XP 8 lib-project API

### DIFF
--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -6,10 +6,8 @@ const mustache = require('/lib/mustache');
 const projectData = {
     id: 'default',
     displayName: 'Default',
-    description: 'Test data for ui-testing',   
-    readAccess: {
-        public: true
-    }
+    description: 'Test data for ui-testing',
+    publicRead: true
 }
 
 function runInContext(callback) {


### PR DESCRIPTION
## Summary

`enonic/xp#12043` reshaped `/lib/xp/project` on XP 8 master. The
`readAccess: { public: <bool> }` parameter on `create()` is replaced
by a flat `publicRead: <bool>`, with no backward-compat shim.

This app's only `lib-project` call site is in
`src/main/resources/main.js`, where `initializeProject()` calls
`projectLib.create({..., readAccess: {public: true}})` to bootstrap
the `default` content project on first start. Without this migration
the call fails at runtime under XP 8.

## Changes

- `src/main/resources/main.js`: rewrite the `projectData` literal
  from `readAccess: {public: true}` to `publicRead: true`. No other
  lib-project surface (`modify`, `modifyReadAccess`/`setPublicRead`,
  Project shape reads) is exercised by this app, and there are no
  lib-content reads of the project root path `/`.

## Test plan

- [x] `./gradlew build --refresh-dependencies` green (no test
      sources in this app, so build is the only local gate)
- [ ] Bootstraps the `default` project successfully against an
      XP 8 runtime — picked up implicitly when downstream UI-test
      suites (`uitest-*`) deploy this app

## References

- Source PR: enonic/xp#12043 (merged 2026-05-18)
- Migration recipe: `enonic/doc-code` → `docs/libraries/lib-project.adoc`
  and `docs/upgrade.adoc` (lib-project section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)